### PR TITLE
77 fix console errors

### DIFF
--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -20,7 +20,8 @@ export const createFetcher = (isLoaded: boolean, isAuthenticated: boolean | null
         if(!isLoaded || !isAuthenticated){
           console.log("stopping fecht because it is not loaded")
           console.log("isLoaded: ", isLoaded, " isAuthenticated: ", isAuthenticated)
-          return Promise.resolve([] as T);
+          return Promise.resolve(["notAllowedToFetch"
+          ] as T);
         }
         const api = await fetchAPIURL();
         console.log("Starting Fetch")
@@ -34,7 +35,7 @@ export const createFetcher = (isLoaded: boolean, isAuthenticated: boolean | null
          });
          if(response.status == 401 && !isLoaded){
           console.log("My special case has happend!!!!")
-          console.log(Promise.resolve([] as T));
+          console.log(Promise.resolve(["dickhead", "dickhead"] as T));
           return Promise.resolve([] as T);
          }else if (!response.ok) {
            throw new Error(`Error when calling (${method} ${endpoint}): ${response.status}`);

--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -27,7 +27,9 @@ export const createFetcher = (token: string | null, navigate: NavigateFunction) 
            },
            body: body ? JSON.stringify(body) : undefined,
          });
-         if (!response.ok) {
+         if(response.status == 401 && !isLoaded){
+          return Promise.reject();
+         }else if (!response.ok) {
            throw new Error(`Error when calling (${method} ${endpoint}): ${response.status}`);
          }
 

--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -15,7 +15,7 @@ async function fetchAPIURL(): Promise<string> {
 
 export type FetchFromBackendType = ReturnType<typeof createFetcher>["fetchFromBackend"];
 
-export const createFetcher = (isLoaded: boolean, isAuthenticated: boolean, token: string | null, navigate: NavigateFunction) => {
+export const createFetcher = (isLoaded: boolean, isAuthenticated: boolean | null, token: string | null, navigate: NavigateFunction) => {
     async function fetchFromBackend<T>({ method, endpoint, body }: FetchOptions): Promise<T> {
         if(!isLoaded || !isAuthenticated){
           console.log("stopping fecht because it is not loaded")

--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -28,7 +28,8 @@ export const createFetcher = (isLoaded: boolean, token: string | null, navigate:
            body: body ? JSON.stringify(body) : undefined,
          });
          if(response.status == 401 && !isLoaded){
-          return Promise.reject();
+          console.log("My special case has happend!!!!")
+          return Promise.resolve(undefined as unknown as T);
          }else if (!response.ok) {
            throw new Error(`Error when calling (${method} ${endpoint}): ${response.status}`);
          }

--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -15,8 +15,8 @@ async function fetchAPIURL(): Promise<string> {
 
 export type FetchFromBackendType = ReturnType<typeof createFetcher>["fetchFromBackend"];
 
-export const createFetcher = (token: string | null, navigate: NavigateFunction) => {
-    async function fetchFromBackend<T>({ method, endpoint, body }: FetchOptions, isLoaded: boolean): Promise<T> {
+export const createFetcher = (isLoaded: boolean, token: string | null, navigate: NavigateFunction) => {
+    async function fetchFromBackend<T>({ method, endpoint, body }: FetchOptions): Promise<T> {
         const api = await fetchAPIURL();
         
         const response = await fetch(`${api}/${endpoint}`, {

--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -19,6 +19,7 @@ export const createFetcher = (isLoaded: boolean, isAuthenticated: boolean, token
     async function fetchFromBackend<T>({ method, endpoint, body }: FetchOptions): Promise<T> {
         if(!isLoaded || !isAuthenticated){
           console.log("stopping fecht because it is not loaded")
+          console.log("isLoaded: ", isLoaded, " isAuthenticated: ", isAuthenticated)
           return Promise.resolve([] as T);
         }
         const api = await fetchAPIURL();

--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -16,7 +16,7 @@ async function fetchAPIURL(): Promise<string> {
 export type FetchFromBackendType = ReturnType<typeof createFetcher>["fetchFromBackend"];
 
 export const createFetcher = (token: string | null, navigate: NavigateFunction) => {
-    async function fetchFromBackend<T>({ method, endpoint, body }: FetchOptions): Promise<T> {
+    async function fetchFromBackend<T>({ method, endpoint, body }: FetchOptions, isLoaded: boolean): Promise<T> {
         const api = await fetchAPIURL();
         
         const response = await fetch(`${api}/${endpoint}`, {

--- a/src/api/createFetcher.ts
+++ b/src/api/createFetcher.ts
@@ -15,10 +15,14 @@ async function fetchAPIURL(): Promise<string> {
 
 export type FetchFromBackendType = ReturnType<typeof createFetcher>["fetchFromBackend"];
 
-export const createFetcher = (isLoaded: boolean, token: string | null, navigate: NavigateFunction) => {
+export const createFetcher = (isLoaded: boolean, isAuthenticated: boolean, token: string | null, navigate: NavigateFunction) => {
     async function fetchFromBackend<T>({ method, endpoint, body }: FetchOptions): Promise<T> {
+        if(!isLoaded || !isAuthenticated){
+          console.log("stopping fecht because it is not loaded")
+          return Promise.resolve([] as T);
+        }
         const api = await fetchAPIURL();
-        
+        console.log("Starting Fetch")
         const response = await fetch(`${api}/${endpoint}`, {
             method,
             headers: {
@@ -29,11 +33,13 @@ export const createFetcher = (isLoaded: boolean, token: string | null, navigate:
          });
          if(response.status == 401 && !isLoaded){
           console.log("My special case has happend!!!!")
-          return Promise.resolve(undefined as unknown as T);
+          console.log(Promise.resolve([] as T));
+          return Promise.resolve([] as T);
          }else if (!response.ok) {
            throw new Error(`Error when calling (${method} ${endpoint}): ${response.status}`);
          }
-
+         
+         //console.log("Answer: ", response.json());
          return response.json();
     }
     async function unsafeFetchFromBackend({ method, endpoint, body }: FetchOptions): Promise<T> {

--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -32,7 +32,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const [isAuthenticated, setIsAuthenticated] = React.useState<boolean | null>(null);
     
 
-    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(isLoaded, isAuthenticated, token, navigate), [token, navigate])
+    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(isLoaded, isAuthenticated, token, navigate), [token, navigate, isAuthenticated])
     
     const checkAuthentication = () => {
         console.log("Token:", token);

--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -32,7 +32,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const [isAuthenticated, setIsAuthenticated] = React.useState<boolean | null>(null);
     
 
-    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(token, navigate), [token, navigate])
+    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(isLoaded, token, navigate), [token, navigate])
     
     const checkAuthentication = () => {
         console.log("Token:", token);

--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -53,7 +53,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
                 }else if(response.status === 401){
                     console.log("User is not authenticated");
                     //navigate("/");
-                    //setToken(null);
+                    setToken(null);
                     //setUsername(null);
                     setIsAuthenticated(false);
                 }else{

--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -32,7 +32,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const [isAuthenticated, setIsAuthenticated] = React.useState<boolean | null>(null);
     
 
-    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(isLoaded, token, navigate), [token, navigate])
+    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(isLoaded, isAuthenticated, token, navigate), [token, navigate])
     
     const checkAuthentication = () => {
         console.log("Token:", token);

--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -32,7 +32,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const [isAuthenticated, setIsAuthenticated] = React.useState<boolean | null>(null);
     
 
-    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(isLoaded, isAuthenticated, token, navigate), [token, navigate, isAuthenticated])
+    const {fetchFromBackend, unsafeFetchFromBackend} = useMemo(() => createFetcher(isLoaded, isAuthenticated, token, navigate), [token, navigate, isAuthenticated]) // Maybe add isLoaded but prob. not needed because it only changes when token also changes from null to some value
     
     const checkAuthentication = () => {
         console.log("Token:", token);

--- a/src/app/modules/DetailExamPage.tsx
+++ b/src/app/modules/DetailExamPage.tsx
@@ -20,6 +20,10 @@ function DetailExamPage() {
             method: "GET",
             endpoint: `data/exam?id=${examId}&course_id=${moduleId}`,
           })
+          if(data.length===1 && typeof data[0] === "string"){
+              console.log("Fetch wasnt allwed detected")
+              return;
+          }
           if (data.length > 0) {
             setExam({
               id: data[0].id,

--- a/src/app/modules/DetailTopicPage.tsx
+++ b/src/app/modules/DetailTopicPage.tsx
@@ -20,6 +20,10 @@ function DetailTopicPage() {
           method: "GET",
           endpoint: `data/topic?id=${topicId}&course_id=${moduleId}`,
         })
+        if(data.length===1 && typeof data[0] === "string"){
+            console.log("Fetch wasnt allwed detected")
+            return;
+        }
         if (data.length > 0) {
           setTopic({
             id: data[0].id,

--- a/src/app/modules/ModulPage.tsx
+++ b/src/app/modules/ModulPage.tsx
@@ -92,16 +92,20 @@ function ModulPage() {
     useEffect(() => {
         const loadData = async () => {
             try {
-                const data = await fetchFromBackend<{ id: number; name: string; details: string }[]>({
+                const data = await fetchFromBackend<({ id: number; name: string; details: string }| string)[]>({
                     method: "GET",
                     endpoint: "data/course",
                 });
+                if(data.length===1 && typeof data[0] === "string"){
+                    console.log("Fetch wasnt allwed detected")
+                    return;
+                }
                 setItems(data);
             } catch (err) {
                 console.error("Error while loading the Courses:", err);
             }
         };    
-      loadData();
+        loadData();
     }, [fetchFromBackend]);
 
     return (

--- a/src/app/modules/TopicPage.tsx
+++ b/src/app/modules/TopicPage.tsx
@@ -12,7 +12,7 @@ function TopicPage(): JSX.Element {
     const [ exams, setExams] = useState<BoxData[]>([]);
     const headerSetter = useContext(HeaderContext);
 
-    const { fetchFromBackend } = useAuth();
+    const { fetchFromBackend, isLoaded } = useAuth();
     
     const handleRenameExam = async (id: number, newTitle: string) => {
         const item = exams.find(item => item.id === id);
@@ -107,7 +107,7 @@ function TopicPage(): JSX.Element {
         const loadData = async () => {
             try {
                 const [dataTopics, dataExams, dataModule] = await Promise.all([
-                    fetchFromBackend<{ id: number; name: string; details: string }[]>({
+                    fetchFromBackend<({ id: number; name: string; details: string } | string)[] >({
                         method: "GET",
                         endpoint: `data/topic?course_id=${moduleId}`
                     }),
@@ -115,13 +115,28 @@ function TopicPage(): JSX.Element {
                         method: "GET",
                         endpoint: `data/exam?course_id=${moduleId}`
                     }),
-                    fetchFromBackend<{ id: number; name: string; }[]>({
+                    fetchFromBackend<({ id: number; name: string; }|string)[]>({
                         method: "GET",
                         endpoint: `data/course?id=${moduleId}`
                     })
                 ]);
+                if(dataModule.length===1 && typeof dataModule[0] === "string"){
+                    console.log("Fetch wasnt allwed detected")
+                    return;
+                }
+                if(dataExams.length===1 && typeof dataExams[0] === "string"){
+                    console.log("Fetch wasnt allwed detected")
+                    return;
+                }
+                if(dataTopics.length===1 && typeof dataTopics[0] === "string"){
+                    console.log("Fetch wasnt allwed detected")
+                    return;
+                }
 
-                if (dataModule.length === 0) {
+                if (dataModule.length === 0 && isLoaded) {
+                    console.log("blablabla")
+                    console.log(dataModule);
+                    console.log(isLoaded)
                     navigate("/404", { replace: true });
                     return;
                 }

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -1,10 +1,9 @@
-import { StrictMode, useContext, useState, createContext, useEffect } from 'react'
+import { useContext, useState, createContext, useEffect } from 'react'
 // import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './app/App.tsx'
 import ReactDOM from 'react-dom/client';
 import { Outlet } from "react-router"
-import { fetchFromBackend } from './fetchBackend.tsx';
 import { useNavigate } from 'react-router-dom';
 
 // const root = ReactDOM.createRoot(document.getElementById('root')!);
@@ -25,75 +24,73 @@ import { useNavigate } from 'react-router-dom';
 // )
 // 
 
-type AccountContextType = {
-  authenticated: boolean;
-  checkAuthentication?: () => void;
-  token: string | undefined;
-};
-
-const AccountContext = createContext<AccountContextType>({
-  authenticated: false,
-  checkAuthentication: () => {},
-  token: undefined
-});
+// type AccountContextType = {
+//   authenticated: boolean;
+//   checkAuthentication?: () => void;
+//   token: string | undefined;
+// };
+// 
+// const AccountContext = createContext<AccountContextType>({
+//   authenticated: false,
+//   checkAuthentication: () => {},
+//   token: undefined
+// });
 
 export default function Root() {
-  const navigation = useNavigate();
+  // const navigation = useNavigate();
 
-  const [authenticated, setAuthenticated] = useState(false);
-  const [token, setToken] = useState<string | undefined>(undefined);
+  // const [authenticated, setAuthenticated] = useState(false);
+  // const [token, setToken] = useState<string | undefined>(undefined);
 
   // Runs when the component mounts to the dom
-  useEffect(() => {
-    if(token !== undefined) {
-      console.log("Token is set, user is authenticated");
-      checkAuthentication();
-      return;
-    }
-    console.log("Root component mounted; Running getting local storage value for authentication");
-    const localToken = localStorage.getItem('token'); 
-    if (localToken === null || localToken === undefined || localToken === "" ){
-      console.log("No token found in local storage, user is not authenticated");
-      setAuthenticated(false);
-      setToken("");
-      navigation("/");
-    } else {
-      console.log("Token found in local storage");
-      setToken(localToken);
-      checkAuthentication();
-    }
-  }, []);
+  //useEffect(() => {
+  //  if(token !== undefined) {
+  //    console.log("Token is set, user is authenticated");
+  //    checkAuthentication();
+  //    return;
+  //  }
+  //  console.log("Root component mounted; Running getting local storage value for authentication");
+  //  const localToken = localStorage.getItem('token'); 
+  //  if (localToken === null || localToken === undefined || localToken === "" ){
+  //    console.log("No token found in local storage, user is not authenticated");
+  //    setAuthenticated(false);
+  //    setToken("");
+  //    navigation("/");
+  //  } else {
+  //    console.log("Token found in local storage");
+  //    setToken(localToken);
+  //    checkAuthentication();
+  //  }
+  //}, []);
 
-  const checkAuthentication = async () => {
-    try {
-      await fetchFromBackend({
-        method: "GET",
-        endpoint: "data/course",
-    })
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        if(error.message.includes("401")){
-          console.error("Unauthorized access, user is not authenticated");
-          setAuthenticated(false);
-          navigation("/");
-          localStorage.removeItem('token'); 
-        }
-      } else {
-        throw error
-      }
-    }
-    setAuthenticated(true);
-  };
+  // const checkAuthentication = async () => {
+  //   try {
+  //     await fetchFromBackend({
+  //       method: "GET",
+  //       endpoint: "data/course",
+  //   })
+  //   } catch (error: unknown) {
+  //     if (error instanceof Error) {
+  //       if(error.message.includes("401")){
+  //         console.error("Unauthorized access, user is not authenticated");
+  //         setAuthenticated(false);
+  //         navigation("/");
+  //         localStorage.removeItem('token'); 
+  //       }
+  //     } else {
+  //       throw error
+  //     }
+  //   }
+  //   setAuthenticated(true);
+  // };
 
-  const contextValue = {
-    authenticated,
-    checkAuthentication: checkAuthentication,
-    token
-  };
+  // const contextValue = {
+  //   authenticated,
+  //   checkAuthentication: checkAuthentication,
+  //   token
+  // };
 
   return (
-    <AccountContext.Provider value={contextValue}>
       <Outlet />
-    </AccountContext.Provider>
   );
 }


### PR DESCRIPTION
Tried to reduce errors in console as much as possible and removed some old code that was deprecated. 

Now there should only be errors on `auth/verify-token` URL. 
Note that these are all caught and handled (On 401 error, there is no error thrown in code). 
From what I have researched, these are thrown into the console by the browser and can't be disabled without changing the backend response on the request (If you find different information, please tell me).

Per action, there should now only be one error (with one exception, which is specified below).

ToDo (Exception):
If a URL like `/modules/notAuthenticatedModuleId/topics/notAuthenticatedTopicId` is entered, there are two errors thrown. I haven't fully figured this case out.

Please just do some general testing on the authentication and that all requests (backend fetching functions) still work.